### PR TITLE
Node sass update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3815,7 +3815,7 @@
       "requires": {
         "gulp-util": "3.0.8",
         "lodash.clonedeep": "4.5.0",
-        "node-sass": "3.13.1",
+        "node-sass": "^4.0.0",
         "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3815,7 +3815,7 @@
       "requires": {
         "gulp-util": "3.0.8",
         "lodash.clonedeep": "4.5.0",
-        "node-sass": "^4.0.0",
+        "node-sass": "3.13.1",
         "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gulp-eslint": "^2.0.0",
     "gulp-import-css": "^0.1.2",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.2.0",
+    "gulp-sass": "^4.0.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.5",


### PR DESCRIPTION
Change is based on gulp-sass dependency that requires node-sass.
The update will reflect over node-sass update that solves some conflict issues related to linux environment.